### PR TITLE
Order projects by activity

### DIFF
--- a/src/store/projects.js
+++ b/src/store/projects.js
@@ -158,6 +158,7 @@ export default {
                 'path',
                 'name',
                 'status',
+                'last_used',
             ])
 
             commit('updateKeys', {

--- a/src/store/projects.js
+++ b/src/store/projects.js
@@ -59,6 +59,11 @@ export default {
                 stopped: 'start',
             })
 
+            dispatch('updateSetting', {
+                id: project.id,
+                key: 'last_used',
+                value: Date.now(),
+            })
             dispatch(action, project)
         },
 

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -146,8 +146,22 @@
 
         computed: {
             ...mapGetters({
-                projects: 'projects/all',
+                unorderedProjects: 'projects/all',
             }),
+
+            projects() {
+                return [...this.unorderedProjects].sort((a, b) => {
+                    if (a.last_used < b.last_used) {
+                        return 1
+                    }
+
+                    if (a.last_used > b.last_used) {
+                        return -1
+                    }
+
+                    return 0
+                })
+            },
         },
     }
 </script>

--- a/src/views/create/Laravel.vue
+++ b/src/views/create/Laravel.vue
@@ -220,6 +220,7 @@
                 },
                 project: {
                     id: uuid(),
+                    last_used: Date.now(),
                     path: '',
                     repository: null,
                     status: null,

--- a/src/views/import/Laravel.vue
+++ b/src/views/import/Laravel.vue
@@ -208,6 +208,7 @@
             return {
                 values: {
                     id: uuid(),
+                    last_used: Date.now(),
                     path: '',
                     repository: null,
                     status: null,


### PR DESCRIPTION
This PR adds a `last_used' property to projects. This property is used to sort projects in the home view.

Fixes #6 